### PR TITLE
Wire newsletter subscribe form to Google Sheet

### DIFF
--- a/NEWSLETTER.md
+++ b/NEWSLETTER.md
@@ -1,0 +1,55 @@
+# Newsletter signups
+
+The **Subscribe** form (`_includes/subscribe-form.html`) collects email
+addresses for the blog's new-post newsletter.
+
+## Where signups go today
+
+Submitted emails are stored in a **Google Sheet**, written by a **Google Apps
+Script Web App**. The Web App URL lives in `_config.yml`:
+
+```yaml
+newsletter_endpoint: "https://script.google.com/macros/s/.../exec"
+```
+
+On submit, the form does a `fetch` POST (form-urlencoded, `mode: 'no-cors'`) of
+the `email` field to that endpoint. The Apps Script `doPost(e)` reads
+`e.parameter.email` and appends `[timestamp, email]` as a new row.
+
+Because Apps Script Web Apps don't return usable CORS headers, the browser sees
+an *opaque* response — we can't read status or body. The accepted pattern is to
+treat a resolved `fetch` promise as success (and a rejected promise, e.g. a
+network failure, as an error).
+
+## How to check the signups
+
+1. Open the Google Sheet backing the Apps Script (from the same Google account
+   that owns the script → **Extensions ▸ Apps Script** shows the bound project).
+2. Each row is `[timestamp, email]`; the newest signups are at the bottom.
+3. To export, use **File ▸ Download** (CSV) or import into your email tool.
+
+If the endpoint ever changes (re-deploying the script mints a new `/exec` URL),
+update `newsletter_endpoint` in `_config.yml`.
+
+## Disabling the form
+
+Set `newsletter_endpoint: ""` in `_config.yml`. The include then hides the form
+and shows a "coming soon" message instead of breaking.
+
+## Swapping to a real email service provider
+
+To move off the Google Sheet onto a hosted provider (Buttondown, Mailchimp,
+ConvertKit, etc.):
+
+1. Create a form/audience with the provider and copy their embed snippet or form
+   `action` endpoint.
+2. Either:
+   - **Simplest:** replace `newsletter_endpoint` in `_config.yml` with the
+     provider's POST endpoint (if it accepts a form-urlencoded `email` field,
+     the existing JS handler may work as-is), **or**
+   - Replace the `<form>` / `<script>` in `_includes/subscribe-form.html` with
+     the provider's official embed snippet.
+3. Rebuild and test a signup end-to-end.
+
+An RSS feed is also available at `/feed.xml` (via `jekyll-feed`) for readers and
+RSS-to-email tools.

--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,14 @@ bluesky_url: https://bsky.app/profile/sumeetkul.bsky.social
 # with JEKYLL_ENV=production (so it never runs during local development).
 google_analytics: "G-S471MH9P0S"
 
+# Newsletter subscribe endpoint.
+# Points at a Google Apps Script Web App whose doPost(e) appends
+# [timestamp, e.parameter.email] to a Google Sheet (the current signup store).
+# Set this to "" to disable the form (it falls back to a "coming soon" message).
+# Swap this for a real ESP form endpoint later (Buttondown/Mailchimp/ConvertKit)
+# by replacing the URL and the submit handler in _includes/subscribe-form.html.
+newsletter_endpoint: "https://script.google.com/macros/s/AKfycbyHdGbSAXfLpxmJtCMVATPsuW3wYES1la3O9dsiH-RNIRyrDzwCppuxxb8zJKAgYxF9bA/exec"
+
 # build settings
 markdown: kramdown
 
@@ -71,6 +79,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - POSTING.md
+  - NEWSLETTER.md
   - AUDIT.md
   - CONTRIBUTING.md
   - forty_jekyll_theme.gemspec

--- a/_includes/subscribe-form.html
+++ b/_includes/subscribe-form.html
@@ -1,15 +1,18 @@
 <!--
 	Newsletter subscribe form.
 
-	This is a placeholder: action="#" does nothing yet. To make it live, sign up
-	with an email newsletter provider and replace the form's `action` (and, if
-	needed, the input `name` attributes) with the embed/endpoint they give you.
-	Common options:
-	  - Buttondown:  https://buttondown.email/  (action="https://buttondown.email/api/emails/embed-subscribe/USERNAME")
-	  - Mailchimp:   https://mailchimp.com/     (embedded form action URL)
-	  - ConvertKit:  https://convertkit.com/    (form action URL)
-	An RSS feed is already available at /feed.xml (via jekyll-feed) for readers
-	and for RSS-to-email tools.
+	Signups are stored in a Google Sheet via a Google Apps Script Web App whose
+	URL lives in _config.yml under `newsletter_endpoint`. On submit we POST the
+	email (form-urlencoded) to that endpoint with fetch + mode:'no-cors'. Apps
+	Script Web Apps don't return CORS headers, so the response is opaque; the
+	accepted pattern is to treat a resolved promise as success.
+
+	To move to a real email provider later, replace `newsletter_endpoint` in
+	_config.yml (or swap the submit handler below) with the provider's endpoint:
+	  - Buttondown:  https://buttondown.email/
+	  - Mailchimp:   https://mailchimp.com/
+	  - ConvertKit:  https://convertkit.com/
+	See NEWSLETTER.md for details. An RSS feed is also available at /feed.xml.
 -->
 <section class="subscribe">
 	<div class="inner">
@@ -17,7 +20,8 @@
 			<h3>Subscribe</h3>
 		</header>
 		<p>Get an email when I publish a new post. No spam, unsubscribe anytime.</p>
-		<form action="#" method="post" class="subscribe-form">
+		{% if site.newsletter_endpoint and site.newsletter_endpoint != "" %}
+		<form id="subscribe-form" class="subscribe-form" data-endpoint="{{ site.newsletter_endpoint }}">
 			<div class="field">
 				<label class="label" for="subscribe-email">Email address</label>
 				<input type="email" name="email" id="subscribe-email" placeholder="you@example.com" required />
@@ -26,5 +30,50 @@
 				<li><input type="submit" value="Subscribe" class="special" /></li>
 			</ul>
 		</form>
+		<p id="subscribe-message" style="display: none;"></p>
+		<script>
+			(function () {
+				var form = document.getElementById('subscribe-form');
+				if (!form) return;
+				var message = document.getElementById('subscribe-message');
+				var button = form.querySelector('input[type="submit"]');
+				var emailInput = document.getElementById('subscribe-email');
+				var emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+				function showMessage(text) {
+					message.textContent = text;
+					message.style.display = '';
+				}
+
+				form.addEventListener('submit', function (event) {
+					event.preventDefault();
+					var email = (emailInput.value || '').trim();
+					if (!email || !emailRe.test(email)) {
+						showMessage('Please enter a valid email address.');
+						return;
+					}
+
+					button.disabled = true;
+					showMessage('Subscribing…');
+
+					fetch(form.getAttribute('data-endpoint'), {
+						method: 'POST',
+						mode: 'no-cors',
+						body: new URLSearchParams({ email: email })
+					}).then(function () {
+						// Opaque response under no-cors; a resolved promise means the
+						// request was sent, which we treat as success.
+						form.style.display = 'none';
+						showMessage("Thanks — you're subscribed!");
+					}).catch(function () {
+						button.disabled = false;
+						showMessage('Something went wrong. Please try again.');
+					});
+				});
+			})();
+		</script>
+		{% else %}
+		<p><em>Newsletter signups are coming soon.</em></p>
+		{% endif %}
 	</div>
 </section>


### PR DESCRIPTION
## Summary

Wires the newsletter subscribe form (added in #8 as a placeholder with `action="#"`) up to a live Google Apps Script Web App that appends signups to a Google Sheet.

- **`_config.yml`** — adds a `newsletter_endpoint` key (following the `google_analytics` pattern) pointing at the Apps Script Web App, with a comment noting it can be swapped for a real ESP (Buttondown/Mailchimp/ConvertKit) later. Also excludes `NEWSLETTER.md` from the build alongside `POSTING.md`/`AUDIT.md`.
- **`_includes/subscribe-form.html`** — replaces the `action="#"` placeholder with a real submit flow:
  - Form gets an `id` and the endpoint is rendered via Liquid into a `data-endpoint` attribute.
  - Vanilla JS (no new deps) intercepts submit, does basic email regex validation, then POSTs form-urlencoded (`URLSearchParams`) via `fetch` with `mode: 'no-cors'`.
  - Because Apps Script returns an opaque response under `no-cors`, a resolved promise is treated as success — shows an inline "Thanks — you're subscribed!" message in place of the form; a rejected promise or failed validation shows an inline error.
  - Submit button is disabled while in flight and re-enabled on error to prevent double-submits.
  - If `site.newsletter_endpoint` is empty/unset, the form is replaced by a graceful "coming soon" message.
  - Uses existing Forty theme classes only; no new CSS.
- **`NEWSLETTER.md`** — documents where signups are stored (Google Sheet via the Apps Script endpoint in `_config.yml`), how to check the sheet, how to disable the form, and how to swap to a real ESP later.

## Testing

- `bundle exec jekyll build` succeeds; only pre-existing sass deprecation warnings remain.
- Verified the endpoint renders correctly into the `data-endpoint` attribute in the built `_site` output.

---
🤖 *Generated by Computer*