### PR TITLE
Fix CI: bump Ruby to 3.3 for Jekyll build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Or a version compatible with your Jekyll version
+          ruby-version: '3.3' # Or a version compatible with your Jekyll version
           bundler-cache: true # Runs 'bundle install' and caches installed gems
 
       - name: Build with Jekyll


### PR DESCRIPTION
## Summary
- The `Build and Deploy Jekyll Site` workflow was failing during `bundle install` with: `public_suffix-7.0.5 requires ruby version >= 3.2, which is incompatible with the current version, 3.1.7`.
- `ruby/setup-ruby@v1` pinned `ruby-version: '3.1'`. Bumped it to `'3.3'` — a stable, widely-available GitHub-hosted runner version compatible with Jekyll 4.4.1 and all current Gemfile dependencies.
- No `ruby "..."` constraint exists in the `Gemfile` or `forty_jekyll_theme.gemspec`, so no other files needed updating for consistency.

## Testing
- [x] `bundle install` succeeds on Ruby 3.3.8 (the step that previously failed).
- [x] `JEKYLL_ENV=production bundle exec jekyll build` completes successfully (only non-fatal Sass deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)