### PR TITLE
Dual-write newsletter signups to Buttondown + Google Sheet

### DIFF
--- a/NEWSLETTER.md
+++ b/NEWSLETTER.md
@@ -5,21 +5,51 @@ addresses for the blog's new-post newsletter.
 
 ## Where signups go today
 
-Submitted emails are stored in a **Google Sheet**, written by a **Google Apps
-Script Web App**. The Web App URL lives in `_config.yml`:
+On submit, the form **dual-writes** each email, in parallel, to two places:
+
+1. **Google Sheet** (backup log) — written by a **Google Apps Script Web App**.
+2. **Buttondown** (<https://buttondown.com/the.sumeetsonian>) — the actual
+   service used to compose and send the newsletter.
+
+### (a) Google Sheet backup log
+
+The Web App URL lives in `_config.yml`:
 
 ```yaml
 newsletter_endpoint: "https://script.google.com/macros/s/.../exec"
 ```
 
-On submit, the form does a `fetch` POST (form-urlencoded, `mode: 'no-cors'`) of
-the `email` field to that endpoint. The Apps Script `doPost(e)` reads
-`e.parameter.email` and appends `[timestamp, email]` as a new row.
+The form does a `fetch` POST (form-urlencoded, `mode: 'no-cors'`) of the `email`
+field to that endpoint. The Apps Script `doPost(e)` reads `e.parameter.email`
+and appends `[timestamp, email]` as a new row. This is an intentional backup log
+and stays as-is.
 
-Because Apps Script Web Apps don't return usable CORS headers, the browser sees
-an *opaque* response — we can't read status or body. The accepted pattern is to
-treat a resolved `fetch` promise as success (and a rejected promise, e.g. a
-network failure, as an error).
+### (b) Buttondown (the sending service)
+
+Buttondown is where the newsletter is actually composed and sent. The form also
+POSTs the same `email` to Buttondown's public, no-API-key **embed-subscribe**
+endpoint. Only the username is stored in `_config.yml` (non-secret); the URL is
+built from it in the Liquid template:
+
+```yaml
+buttondown_username: "the.sumeetsonian"
+```
+
+→ `https://buttondown.com/api/emails/embed-subscribe/the.sumeetsonian`
+
+**Double opt-in:** Buttondown likely has double opt-in enabled by default, so a
+new subscriber may receive a **confirmation email** and won't be fully
+subscribed until they click the link in it. This is expected — don't be
+surprised if the Sheet has an email that isn't yet confirmed in Buttondown. You
+can change this in the Buttondown settings if you prefer single opt-in.
+
+### Opaque responses (both endpoints)
+
+Neither endpoint returns usable CORS headers, so the browser sees *opaque*
+responses — we can't read status or body. The accepted pattern is to treat a
+resolved `fetch` promise as success (and a rejected promise, e.g. a network
+failure, as an error). The success/thank-you message is keyed off the Google
+Sheet request.
 
 ## How to check the signups
 
@@ -36,20 +66,18 @@ update `newsletter_endpoint` in `_config.yml`.
 Set `newsletter_endpoint: ""` in `_config.yml`. The include then hides the form
 and shows a "coming soon" message instead of breaking.
 
-## Swapping to a real email service provider
+## Checking Buttondown subscribers
 
-To move off the Google Sheet onto a hosted provider (Buttondown, Mailchimp,
-ConvertKit, etc.):
+Log in at <https://buttondown.com/the.sumeetsonian> to see the subscriber list,
+compose issues, and send the newsletter. Remember that double opt-in means a
+subscriber only appears as confirmed once they click the confirmation email.
 
-1. Create a form/audience with the provider and copy their embed snippet or form
-   `action` endpoint.
-2. Either:
-   - **Simplest:** replace `newsletter_endpoint` in `_config.yml` with the
-     provider's POST endpoint (if it accepts a form-urlencoded `email` field,
-     the existing JS handler may work as-is), **or**
-   - Replace the `<form>` / `<script>` in `_includes/subscribe-form.html` with
-     the provider's official embed snippet.
-3. Rebuild and test a signup end-to-end.
+## Changing the Buttondown account
+
+If the Buttondown username ever changes, update `buttondown_username` in
+`_config.yml`; the embed-subscribe URL is derived from it automatically. Setting
+it to `""` disables the second (Buttondown) write while leaving the Google Sheet
+backup log intact.
 
 An RSS feed is also available at `/feed.xml` (via `jekyll-feed`) for readers and
 RSS-to-email tools.

--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,14 @@ google_analytics: "G-S471MH9P0S"
 # by replacing the URL and the submit handler in _includes/subscribe-form.html.
 newsletter_endpoint: "https://script.google.com/macros/s/AKfycbyHdGbSAXfLpxmJtCMVATPsuW3wYES1la3O9dsiH-RNIRyrDzwCppuxxb8zJKAgYxF9bA/exec"
 
+# Buttondown newsletter (the actual sending service).
+# On submit, the subscribe form ALSO POSTs the email to Buttondown's public,
+# no-API-key embed-subscribe endpoint, built as:
+#   https://buttondown.com/api/emails/embed-subscribe/<buttondown_username>
+# This is non-secret (it's the public signup path). The Google Sheet above is
+# kept as a parallel backup log. See NEWSLETTER.md.
+buttondown_username: "the.sumeetsonian"
+
 # build settings
 markdown: kramdown
 

--- a/_includes/subscribe-form.html
+++ b/_includes/subscribe-form.html
@@ -1,17 +1,19 @@
 <!--
 	Newsletter subscribe form.
 
-	Signups are stored in a Google Sheet via a Google Apps Script Web App whose
-	URL lives in _config.yml under `newsletter_endpoint`. On submit we POST the
-	email (form-urlencoded) to that endpoint with fetch + mode:'no-cors'. Apps
-	Script Web Apps don't return CORS headers, so the response is opaque; the
-	accepted pattern is to treat a resolved promise as success.
+	On submit the visitor's email is dual-written to two endpoints in parallel:
 
-	To move to a real email provider later, replace `newsletter_endpoint` in
-	_config.yml (or swap the submit handler below) with the provider's endpoint:
-	  - Buttondown:  https://buttondown.email/
-	  - Mailchimp:   https://mailchimp.com/
-	  - ConvertKit:  https://convertkit.com/
+	  1. Google Apps Script Web App (`newsletter_endpoint` in _config.yml) — a
+	     backup log that appends [timestamp, email] to a Google Sheet.
+	  2. Buttondown (the actual sending service) — its public, no-API-key
+	     embed-subscribe endpoint, built from `buttondown_username` in
+	     _config.yml.
+
+	Both POSTs use fetch + mode:'no-cors' (form-urlencoded email). Neither
+	endpoint returns usable CORS headers, so responses are opaque; the accepted
+	pattern is to treat a resolved promise as success. Buttondown may have double
+	opt-in enabled, so the visitor could receive a confirmation email.
+
 	See NEWSLETTER.md for details. An RSS feed is also available at /feed.xml.
 -->
 <section class="subscribe">
@@ -21,7 +23,7 @@
 		</header>
 		<p>Get an email when I publish a new post. No spam, unsubscribe anytime.</p>
 		{% if site.newsletter_endpoint and site.newsletter_endpoint != "" %}
-		<form id="subscribe-form" class="subscribe-form" data-endpoint="{{ site.newsletter_endpoint }}">
+		<form id="subscribe-form" class="subscribe-form" data-endpoint="{{ site.newsletter_endpoint }}"{% if site.buttondown_username and site.buttondown_username != "" %} data-buttondown-endpoint="https://buttondown.com/api/emails/embed-subscribe/{{ site.buttondown_username }}"{% endif %}>
 			<div class="field">
 				<label class="label" for="subscribe-email">Email address</label>
 				<input type="email" name="email" id="subscribe-email" placeholder="you@example.com" required />
@@ -56,13 +58,25 @@
 					button.disabled = true;
 					showMessage('Subscribing…');
 
-					fetch(form.getAttribute('data-endpoint'), {
-						method: 'POST',
-						mode: 'no-cors',
-						body: new URLSearchParams({ email: email })
-					}).then(function () {
-						// Opaque response under no-cors; a resolved promise means the
-						// request was sent, which we treat as success.
+					var payload = new URLSearchParams({ email: email });
+					function post(url) {
+						return fetch(url, {
+							method: 'POST',
+							mode: 'no-cors',
+							body: payload
+						});
+					}
+
+					// Dual-write: Google Sheet backup log + Buttondown (sending
+					// service). Both are opaque under no-cors; a resolved promise
+					// means the request was sent, which we treat as success. The
+					// Sheet log is the source of truth for success messaging.
+					var buttondownEndpoint = form.getAttribute('data-buttondown-endpoint');
+					if (buttondownEndpoint) {
+						post(buttondownEndpoint);
+					}
+
+					post(form.getAttribute('data-endpoint')).then(function () {
 						form.style.display = 'none';
 						showMessage("Thanks — you're subscribed!");
 					}).catch(function () {


### PR DESCRIPTION
## Summary

The site now uses **Buttondown** (<https://buttondown.com/the.sumeetsonian>) as the actual newsletter sending service, in addition to the existing Google Sheet backup log. This wires the subscribe form to **dual-write** each signup to both, with no UI/styling changes.

- `_config.yml`: add non-secret `buttondown_username: "the.sumeetsonian"`. The embed-subscribe URL is derived from it (mirrors how `newsletter_endpoint` is used); no username is hardcoded in the include.
- `_includes/subscribe-form.html`: on submit, fire a second parallel `fetch` (`mode: 'no-cors'`, form-urlencoded `email`) to `https://buttondown.com/api/emails/embed-subscribe/<username>`. The existing Google Apps Script POST is unchanged and remains the source of truth for the success/thank-you message. Form markup, styling, and validation are untouched. If `buttondown_username` is empty, only the Sheet write fires.
- `NEWSLETTER.md`: document that subscribers are dual-written to (a) the Google Sheet backup log and (b) Buttondown (the compose/send service), and note that Buttondown likely has **double opt-in** enabled (visitors may receive a confirmation email).

No API keys, secrets, or GitHub Actions workflows were touched. Confirmed there are no MailerLite references anywhere in the repo.

## Testing

- [x] `ruby -ryaml` parse of `_config.yml` — valid; `buttondown_username` present.
- [x] Liquid `{% if %}`/`{% endif %}` tags balanced in the include.
- [x] `jekyll build` succeeds (only pre-existing SCSS deprecation warnings).
- [x] Rendered `_site` output contains `data-buttondown-endpoint="https://buttondown.com/api/emails/embed-subscribe/the.sumeetsonian"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)